### PR TITLE
Tx submit and event receipt tracking

### DIFF
--- a/cmd/fabconnect.go
+++ b/cmd/fabconnect.go
@@ -62,21 +62,21 @@ type cmdConfig struct {
 }
 
 var rootConfig = cmdConfig{}
-var restGatewayConf = &conf.RESTGatewayConf{}
+var restGatewayConf = conf.RESTGatewayConf{}
 var restGateway *rest.RESTGateway
 
 var rootCmd = &cobra.Command{
 	Use:   "fabconnect",
 	Short: "Connectivity Bridge for Hyperledger Fabric permissioned chains",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		err := viper.Unmarshal(restGatewayConf)
+		err := viper.Unmarshal(&restGatewayConf)
 		if err != nil {
 			return err
 		}
 
 		// allow tests to assign a mock
 		if restGateway == nil {
-			restGateway = rest.NewRESTGateway(restGatewayConf)
+			restGateway = rest.NewRESTGateway(&restGatewayConf)
 		}
 		err = restGateway.ValidateConf()
 		if err != nil {
@@ -95,7 +95,10 @@ var rootCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := startServer()
-		return err
+		if err != nil {
+			return err
+		}
+		return nil
 	},
 }
 
@@ -111,7 +114,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&rootConfig.DebugPort, "debugPort", "Z", 6060, "Port for pprof HTTP endpoints (localhost only)")
 	rootCmd.Flags().BoolVarP(&rootConfig.PrintYAML, "print-yaml-confg", "Y", false, "Print YAML config snippet and exit")
 	rootCmd.Flags().StringVarP(&rootConfig.Filename, "configfile", "f", "", "Configuration file, must be one of .yml, .yaml, or .json")
-	conf.CobraInit(rootCmd, restGatewayConf)
+	conf.CobraInit(rootCmd, &restGatewayConf)
 }
 
 func initConfig() {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/google/certificate-transparency-go v1.1.1 // indirect
 	github.com/gorilla/websocket v1.4.2
+	github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23
 	github.com/hyperledger/fabric-sdk-go v1.0.1-0.20210201220314-86344dc25e5d
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect

--- a/internal/fabric/handler.go
+++ b/internal/fabric/handler.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Kaleido
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fabric
+
+import (
+	"github.com/hyperledger-labs/firefly-fabconnect/internal/errors"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/status"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+)
+
+// adapted from the CommitHandler in https://github.com/hyperledger/fabric-sdk-go
+// in order to custom process the transaction status event
+type txSubmitAndListenHandler struct {
+	txStatusEvent *fab.TxStatusEvent
+}
+
+func NewTxSubmitAndListenHandler(txStatus *fab.TxStatusEvent) *txSubmitAndListenHandler {
+	return &txSubmitAndListenHandler{
+		txStatusEvent: txStatus,
+	}
+}
+
+func (h *txSubmitAndListenHandler) Handle(requestContext *invoke.RequestContext, clientContext *invoke.ClientContext) {
+	txnID := requestContext.Response.TransactionID
+
+	//Register Tx event
+	reg, statusNotifier, err := clientContext.EventService.RegisterTxStatusEvent(string(txnID))
+	if err != nil {
+		requestContext.Error = errors.Errorf("Error registering for TxStatus event for transaction %s. %s", txnID, err)
+		return
+	}
+	defer clientContext.EventService.Unregister(reg)
+
+	_, err = createAndSendTransaction(clientContext.Transactor, requestContext.Response.Proposal, requestContext.Response.Responses)
+	if err != nil {
+		requestContext.Error = errors.Errorf("CreateAndSendTransaction failed. %s", err)
+		return
+	}
+
+	select {
+	case txStatus := <-statusNotifier:
+		requestContext.Response.TxValidationCode = txStatus.TxValidationCode
+		h.txStatusEvent.BlockNumber = txStatus.BlockNumber
+		h.txStatusEvent.SourceURL = txStatus.SourceURL
+		h.txStatusEvent.TxID = txStatus.TxID
+		h.txStatusEvent.TxValidationCode = txStatus.TxValidationCode
+
+		if txStatus.TxValidationCode != pb.TxValidationCode_VALID {
+			requestContext.Error = status.New(status.EventServerStatus, int32(txStatus.TxValidationCode),
+				"received invalid transaction", nil)
+			return
+		}
+	case <-requestContext.Ctx.Done():
+		requestContext.Error = status.New(status.ClientStatus, status.Timeout.ToInt32(),
+			"Execute didn't receive block event", nil)
+		return
+	}
+}
+
+func createAndSendTransaction(sender fab.Sender, proposal *fab.TransactionProposal, resps []*fab.TransactionProposalResponse) (*fab.TransactionResponse, error) {
+
+	txnRequest := fab.TransactionRequest{
+		Proposal:          proposal,
+		ProposalResponses: resps,
+	}
+
+	tx, err := sender.CreateTransaction(txnRequest)
+	if err != nil {
+		return nil, errors.Errorf("Create Transaction failed: %s", err)
+	}
+
+	transactionResponse, err := sender.SendTransaction(tx)
+	if err != nil {
+		return nil, errors.Errorf("Send Transaction failed: %s", err)
+
+	}
+
+	return transactionResponse, nil
+}

--- a/internal/fabric/rpc.go
+++ b/internal/fabric/rpc.go
@@ -16,63 +16,196 @@ package fabric
 
 import (
 	"context"
-	"io/ioutil"
 
 	"github.com/hyperledger-labs/firefly-fabconnect/internal/conf"
+	"github.com/hyperledger-labs/firefly-fabconnect/internal/errors"
 	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/errors/retry"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/msp"
 	"github.com/hyperledger/fabric-sdk-go/pkg/core/config"
+	"github.com/hyperledger/fabric-sdk-go/pkg/core/cryptosuite"
+	"github.com/hyperledger/fabric-sdk-go/pkg/core/cryptosuite/bccsp/sw"
+	fabImpl "github.com/hyperledger/fabric-sdk-go/pkg/fab"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fab/keyvaluestore"
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
+	mspImpl "github.com/hyperledger/fabric-sdk-go/pkg/msp"
 	log "github.com/sirupsen/logrus"
 )
 
 type RPCClient interface {
-	Init(ctx context.Context, channelId, chaincodeName, method string, args []string) (TxReceipt, error)
-	Invoke(ctx context.Context, channelId, chaincodeName, method string, args []string) (TxReceipt, error)
+	Init(ctx context.Context, channelId, signer, chaincodeName, method string, args []string) (*TxReceipt, error)
+	Invoke(ctx context.Context, channelId, signer, chaincodeName, method string, args []string) (*TxReceipt, error)
 	Close()
 }
 
-type rpcWrapper struct {
-	sdk *fabsdk.FabricSDK
-	// msp.IdentityIdentifier.ID <-> channel.Client
-	channelMap map[string]*channel.Client
+type clientWrapper struct {
+	channelClient *channel.Client
+	eventService  fab.EventService
 }
 
-func RPCConnect(c conf.RPCConf) (RPCClient, error) {
-	dat, err := ioutil.ReadFile(c.ConfigPath)
-	if err != nil {
-		log.Errorf("Failed to read common connection profile file: %s. %s", c.ConfigPath, err)
-		return nil, err
-	}
-	configProvider := config.FromRaw(dat, "yaml")
+type rpcWrapper struct {
+	sdk               *fabsdk.FabricSDK
+	cryptoSuiteConfig core.CryptoSuiteConfig
+	identityConfig    msp.IdentityConfig
+	userStore         *mspImpl.CertFileUserStore
+	identityMgr       *mspImpl.IdentityManager
+	// msp.IdentityIdentifier.ID <-> channel.Client
+	// one channel client per channel ID, per signer org, per signer ID
+	channelClients map[string](map[string](map[string]*clientWrapper))
+	txTimeout      int
+}
+
+func RPCConnect(c conf.RPCConf, txTimeout int) (RPCClient, error) {
+	configProvider := config.FromFile(c.ConfigPath)
 	sdk, err := fabsdk.New(configProvider)
 	if err != nil {
-		log.Errorf("Failed to initialize a new SDK instance. %s", err)
-		return nil, err
+		return nil, errors.Errorf("Failed to initialize a new SDK instance. %s", err)
+	}
+	configBackend, _ := configProvider()
+	endpointConfig, err := fabImpl.ConfigFromBackend(configBackend...)
+	if err != nil {
+		return nil, errors.Errorf("Failed to read config: %s", err)
+	}
+	cryptoConfig := cryptosuite.ConfigFromBackend(configBackend...)
+	if err != nil {
+		return nil, errors.Errorf("Failed to load crypto suite configurations: %s", err)
+	}
+	identityConfig, err := mspImpl.ConfigFromBackend(configBackend...)
+	if err != nil {
+		return nil, errors.Errorf("Failed to load identity configurations: %s", err)
+	}
+	clientConfig := identityConfig.Client()
+	if clientConfig.CredentialStore.Path == "" {
+		return nil, errors.Errorf("User credentials store path is empty")
+	}
+	store, err := keyvaluestore.New(&keyvaluestore.FileKeyValueStoreOptions{
+		Path: clientConfig.CredentialStore.Path,
+	})
+	if err != nil {
+		return nil, errors.Errorf("Key-value store creation failed. Path: %s", clientConfig.CredentialStore.Path)
+	}
+	userStore, err := mspImpl.NewCertFileUserStore1(store)
+	if err != nil {
+		return nil, errors.Errorf("User credentials store creation failed. Path: %s", err)
+	}
+	cs, err := sw.GetSuiteByConfig(cryptoConfig)
+	if err != nil {
+		return nil, errors.Errorf("Failed to get suite by config: %s", err)
+	}
+	mgr, err := mspImpl.NewIdentityManager(clientConfig.Organization, userStore, cs, endpointConfig)
+	if err != nil {
+		return nil, errors.Errorf("Identity manager creation failed. %s", err)
 	}
 
 	log.Infof("New gRPC connection established")
-	return &rpcWrapper{sdk: sdk}, nil
+	return &rpcWrapper{
+		sdk:               sdk,
+		cryptoSuiteConfig: cryptoConfig,
+		identityConfig:    identityConfig,
+		userStore:         userStore,
+		identityMgr:       mgr,
+		channelClients:    make(map[string]map[string]map[string]*clientWrapper),
+		txTimeout:         txTimeout,
+	}, nil
 }
 
-func (w *rpcWrapper) Init(ctx context.Context, channelId, chaincodeName, method string, args []string) (TxReceipt, error) {
-	log.Tracef("RPC [%s:%s:%s] --> %+v", channelId, chaincodeName, method, args)
-	result, err := w.channelMap[channelId].Execute(
-		channel.Request{ChaincodeID: chaincodeName, Fcn: method, Args: convert(args), IsInit: true},
-		channel.WithRetry(retry.DefaultChannelOpts),
-	)
-	log.Tracef("RPC [%s:%s:%s] <-- %+v", channelId, chaincodeName, method, result)
-	return newReceipt(result), err
+func (w *rpcWrapper) getChannelClient(channelId string, signer *msp.IdentityIdentifier) (*clientWrapper, error) {
+	allClientsOfChannel := w.channelClients[channelId]
+	if allClientsOfChannel == nil {
+		w.channelClients[channelId] = make(map[string]map[string]*clientWrapper)
+	}
+	channelClientsOfOrg := w.channelClients[channelId][signer.MSPID]
+	if channelClientsOfOrg == nil {
+		w.channelClients[channelId][signer.MSPID] = make(map[string]*clientWrapper)
+	}
+	orgClientOfUser := w.channelClients[channelId][signer.MSPID][signer.ID]
+	if orgClientOfUser == nil {
+		channelContext := w.sdk.ChannelContext(channelId, fabsdk.WithOrg(signer.MSPID), fabsdk.WithUser(signer.ID))
+		newClient, err := channel.New(channelContext)
+		if err != nil {
+			return nil, err
+		}
+		channelProvider, err := channelContext()
+		if err != nil {
+			return nil, err
+		}
+		eventService, err := channelProvider.ChannelService().EventService()
+		if err != nil {
+			return nil, err
+		}
+		newWrapper := &clientWrapper{
+			channelClient: newClient,
+			eventService:  eventService,
+		}
+		w.channelClients[channelId][signer.MSPID][signer.ID] = newWrapper
+		orgClientOfUser = newWrapper
+	}
+	return orgClientOfUser, nil
 }
 
-func (w *rpcWrapper) Invoke(ctx context.Context, channelId, chaincodeName, method string, args []string) (TxReceipt, error) {
+func (w *rpcWrapper) Init(ctx context.Context, channelId, signer, chaincodeName, method string, args []string) (*TxReceipt, error) {
 	log.Tracef("RPC [%s:%s:%s] --> %+v", channelId, chaincodeName, method, args)
-	result, err := w.channelMap[channelId].Execute(
-		channel.Request{ChaincodeID: chaincodeName, Fcn: method, Args: convert(args)},
+
+	signerID, result, txStatus, err := w.sendTransaction(channelId, signer, chaincodeName, method, args, true)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Tracef("RPC [%s:%s:%s] <-- %+v", channelId, chaincodeName, method, result)
+	return newReceipt(result, txStatus, signerID), err
+}
+
+func (w *rpcWrapper) Invoke(ctx context.Context, channelId, signer, chaincodeName, method string, args []string) (*TxReceipt, error) {
+	log.Tracef("RPC [%s:%s:%s] --> %+v", channelId, chaincodeName, method, args)
+
+	signerID, result, txStatus, err := w.sendTransaction(channelId, signer, chaincodeName, method, args, false)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Tracef("RPC [%s:%s:%s] <-- %+v", channelId, chaincodeName, method, result)
+	return newReceipt(result, txStatus, signerID), err
+}
+
+func (w *rpcWrapper) sendTransaction(channelId, signer, chaincodeName, method string, args []string, isInit bool) (*msp.IdentityIdentifier, *channel.Response, *fab.TxStatusEvent, error) {
+	id, err := w.identityMgr.GetSigningIdentity(signer)
+	if err == msp.ErrUserNotFound {
+		return nil, nil, nil, errors.Errorf("Signer %s does not exist", signer)
+	}
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("Failed to retrieve signing identity: %s", err)
+	}
+
+	client, err := w.getChannelClient(channelId, id.Identifier())
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("Failed to get channel client. %s", err)
+	}
+	// in order to hook into the event notification for the transaction, we need to register
+	// by the transaction ID before the transaction is sent to the orderer. Thus we can't use
+	// the Execute() method of the client that consumes the event notification
+	txStatus := fab.TxStatusEvent{}
+	handlerChain := invoke.NewSelectAndEndorseHandler(
+		invoke.NewEndorsementValidationHandler(
+			invoke.NewSignatureValidationHandler(
+				NewTxSubmitAndListenHandler(&txStatus),
+			),
+		),
+	)
+	result, err := client.channelClient.InvokeHandler(
+		handlerChain,
+		channel.Request{ChaincodeID: chaincodeName, Fcn: method, Args: convert(args), IsInit: isInit},
 		channel.WithRetry(retry.DefaultChannelOpts),
 	)
-	log.Tracef("RPC [%s:%s:%s] <-- %+v", channelId, chaincodeName, method, result)
-	return newReceipt(result), err
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return id.Identifier(), &result, &txStatus, nil
 }
 
 func (w *rpcWrapper) Close() {
@@ -87,10 +220,13 @@ func convert(args []string) [][]byte {
 	return result
 }
 
-func newReceipt(response channel.Response) TxReceipt {
-	return TxReceipt{
-		SignerMSP:     string(response.Proposal.Header),
+func newReceipt(response *channel.Response, status *fab.TxStatusEvent, signerID *msp.IdentityIdentifier) *TxReceipt {
+	return &TxReceipt{
+		SignerMSP:     signerID.MSPID,
+		Signer:        signerID.ID,
 		TransactionID: string(response.TransactionID),
-		Status:        int(response.TxValidationCode),
+		Status:        response.TxValidationCode,
+		BlockNumber:   status.BlockNumber,
+		SourcePeer:    status.SourceURL,
 	}
 }

--- a/internal/rest/async/asyncdispatcher.go
+++ b/internal/rest/async/asyncdispatcher.go
@@ -82,8 +82,8 @@ func (d *asyncDispatcher) DispatchMsgAsync(ctx context.Context, msg *messages.Se
 }
 
 func (d *asyncDispatcher) HandleReceipts(res http.ResponseWriter, req *http.Request, params httprouter.Params) {
-	path := req.URL.Path
-	if path == "receipts" {
+	p := req.URL.Path
+	if p == "/receipts" {
 		d.receiptStore.GetReceipts(res, req, params)
 	} else {
 		d.receiptStore.GetReceipt(res, req, params)

--- a/internal/rest/async/directhandler.go
+++ b/internal/rest/async/directhandler.go
@@ -75,10 +75,6 @@ func (t *msgContext) Unmarshal(msg interface{}) error {
 }
 
 func (t *msgContext) SendErrorReply(status int, err error) {
-	t.SendErrorReplyWithGapFill(status, err, "", false)
-}
-
-func (t *msgContext) SendErrorReplyWithGapFill(status int, err error, gapFillTxHash string, gapFillSucceeded bool) {
 	t.SendErrorReplyWithTX(status, err, "")
 }
 

--- a/internal/rest/restgateway.go
+++ b/internal/rest/restgateway.go
@@ -78,7 +78,7 @@ func NewRESTGateway(config *conf.RESTGatewayConf) *RESTGateway {
 }
 
 func (g *RESTGateway) Init() error {
-	rpcClient, err := fabric.RPCConnect(g.config.RPC)
+	rpcClient, err := fabric.RPCConnect(g.config.RPC, g.config.MaxTXWaitTime)
 	if err != nil {
 		return err
 	}

--- a/internal/rest/restgateway_test.go
+++ b/internal/rest/restgateway_test.go
@@ -203,5 +203,5 @@ func TestStartWithBadRPCConfigPath(t *testing.T) {
 	testConfig.RPC.ConfigPath = "/bad/path"
 	g := NewRESTGateway(testConfig)
 	err := g.Init()
-	assert.EqualError(err, "open /bad/path: no such file or directory")
+	assert.EqualError(err, "Failed to initialize a new SDK instance. failed to initialize configuration: unable to load config backend: loading config file failed: /bad/path: Unsupported Config Type \"\"")
 }

--- a/internal/rest/router.go
+++ b/internal/rest/router.go
@@ -41,7 +41,7 @@ func (r *router) addRoutes() {
 
 	r.httpRouter.POST("/transactions", r.sendTransaction)
 	r.httpRouter.GET("/receipts", r.handleReceipts)
-	r.httpRouter.GET("/receipts/:receiptId", r.handleReceipts)
+	r.httpRouter.GET("/receipts/:id", r.handleReceipts)
 
 	// router.POST("/eventstreams", r.createStream)
 	// router.PATCH("/eventstreams/:streamId", r.updateStream)

--- a/internal/rest/test/util.go
+++ b/internal/rest/test/util.go
@@ -46,6 +46,10 @@ var testConfigJSON = `{
   }
 }`
 var testRPCConfig = `name: "test profile"
+client:
+  organization: org1
+  credentialStore:
+    path: "/tmp-client-creds-path"
 organizations:
   org1:
     mspid: "org1MSP"
@@ -126,6 +130,8 @@ func Setup() (string, *conf.RESTGatewayConf) {
 	// modify ca cert path
 	ccp := strings.Replace(testRPCConfig, "/tmp-cert", certPath, 1)
 	// set up crypto path for each org
+	clientCredsPath := path.Join(tmpdir, "client")
+	ccp = strings.Replace(ccp, "/tmp-client-creds-path", clientCredsPath, 1)
 	org1MSPPath := path.Join(tmpdir, "org1")
 	ccp = strings.Replace(ccp, "/tmp-crypto-path-org1", org1MSPPath, 1)
 	org2MSPPath := path.Join(tmpdir, "org2")

--- a/internal/rest/test/util.go
+++ b/internal/rest/test/util.go
@@ -45,6 +45,26 @@ var testConfigJSON = `{
     "configPath": "/test-config-path"
   }
 }`
+var testConfigJSONBad = `{
+  "maxInFlight": "abc",
+  "maxTXWaitTime": 60,
+  "sendConcurrency": 25,
+  "receipts": {
+    "maxDocs": 1000,
+    "queryLimit": 100,
+    "retryInitialDelay": 5,
+    "retryTimeout": 30,
+    "leveldb": {
+      "path": "/test-receipt-path"
+    }
+  },
+  "http": {
+    "port": 3000
+  },
+  "rpc": {
+    "configPath": "/test-config-path"
+  }
+}`
 var testRPCConfig = `name: "test profile"
 client:
   organization: org1
@@ -148,6 +168,7 @@ func Setup() (string, *conf.RESTGatewayConf) {
 	testConfigJSON = strings.Replace(testConfigJSON, "/test-receipt-path", receiptStorePath, 1)
 	// write the config file
 	_ = ioutil.WriteFile(path.Join(tmpdir, "config.json"), []byte(testConfigJSON), 0644)
+	_ = ioutil.WriteFile(path.Join(tmpdir, "config-bad.json"), []byte(testConfigJSONBad), 0644)
 
 	// init the default config
 	testConfig := &conf.RESTGatewayConf{}

--- a/internal/tx/txprocessor.go
+++ b/internal/tx/txprocessor.go
@@ -120,6 +120,7 @@ func (p *txProcessor) addInflightWrapper(txContext TxContext, msg *messages.Tran
 
 	inflight = &inflightTx{
 		txContext: txContext,
+		signer:    msg.Headers.Signer,
 	}
 
 	// Use the correct RPC for sending transactions
@@ -213,8 +214,8 @@ func (p *txProcessor) waitForCompletion(inflight *inflightTx, initialWaitDelay t
 		p.inflightTxsLock.Unlock()
 
 		receipt := inflight.tx.Receipt
-		isSuccess := receipt.Status == 0
-		log.Infof("Receipt for %s obtained after %.2fs Success=%t", inflight.tx.Hash, elapsed.Seconds(), isSuccess)
+		isSuccess := receipt.IsSuccess()
+		log.Infof("Receipt for %s obtained after %.2fs Success=%t", inflight.tx.Receipt.TransactionID, elapsed.Seconds(), isSuccess)
 
 		// Build our reply
 		var reply messages.TransactionReceipt


### PR DESCRIPTION
For async requests, added more complete support for submitting Fabric transactions and tracking the transaction status event, and saving the result in the receipt store.

Example request:
```
curl -H "Content-Type: application/json" -d '{"headers":{"type":"SendTransaction","channel":"default-channel","signer":"user2"},"chaincode":"asset_transfer","func":"CreateAsset","args":["asset1014","yellow","10","Tom","1300"]}' http://localhost:3000/transactions?fly-sync=true | jq

{
  "sent": true,
  "id": "008185fd-5a28-4e1a-4526-d8f9d8f5cc18"
}
```

```
$ curl http://localhost:3000/receipts/41c0c0a4-46a8-4c46-7289-90705ea70436 |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   347  100   347    0     0   338k      0 --:--:-- --:--:-- --:--:--  338k
{
  "_id": "41c0c0a4-46a8-4c46-7289-90705ea70436",
  "headers": {
    "id": "218310d6-b915-4e52-4cd0-fc147265c49a",
    "requestId": "41c0c0a4-46a8-4c46-7289-90705ea70436",
    "requestOffset": "",
    "timeElapsed": 1.056184,
    "timeReceived": "2021-07-27T18:53:11.317501Z",
    "type": "TransactionSuccess"
  },
  "receivedAt": 1627411992373
}
```

For sync requests, the end to end transaction processing also works now.

```
$ curl -H "Content-Type: application/json" -d '{"headers":{"type":"SendTransaction","channel":"default-channel","signer":"user2"},"chaincode":"asset_transfer","func":"CreateAsset","args":["asset1014","yellow","10","Tom","1300"]}' http://localhost:3000/transactions?fly-sync=true | jq

{
  "headers": {
    "id": "1572b6aa-75a8-4c7c-6f6a-6f1b911c38aa",
    "type": "TransactionSuccess",
    "timeReceived": "2021-07-27T19:42:02.957407Z",
    "timeElapsed": 1.05154,
    "requestOffset": "",
    "requestId": ""
  }
}
```