### PR TITLE
Enrich GET identity endpoint responses with certs and mspID

### DIFF
--- a/internal/fabric/identity.go
+++ b/internal/fabric/identity.go
@@ -136,9 +136,11 @@ func (w *rpcWrapper) Get(res http.ResponseWriter, req *http.Request, params http
 	// we have to retrieve it from the identity manager
 	si, _ := w.identityMgr.GetSigningIdentity(username)
 	var ecert []byte
+	var mspId string
 	if si != nil {
 		// the user may have been enrolled by a different client instance
 		ecert = si.EnrollmentCertificate()
+		mspId = si.Identifier().MSPID
 	}
 
 	// the SDK doesn't save the CACert locally, we have to retrieve it from the Fabric CA server
@@ -153,6 +155,7 @@ func (w *rpcWrapper) Get(res http.ResponseWriter, req *http.Request, params http
 	newId.CAName = result.CAName
 	newId.Type = result.Type
 	newId.Affiliation = result.Affiliation
+	newId.MSPID = mspId
 	newId.EnrollmentCert = ecert
 	newId.CACert = cacert
 	return &newId, nil

--- a/internal/fabric/identity.go
+++ b/internal/fabric/identity.go
@@ -131,32 +131,34 @@ func (w *rpcWrapper) Get(res http.ResponseWriter, req *http.Request, params http
 	if err != nil {
 		return nil, restutil.NewRestError(err.Error(), 500)
 	}
-
-	// the SDK identity manager does not persist the certificates
-	// we have to retrieve it from the identity manager
-	si, _ := w.identityMgr.GetSigningIdentity(username)
-	var ecert []byte
-	var mspId string
-	if si != nil {
-		// the user may have been enrolled by a different client instance
-		ecert = si.EnrollmentCertificate()
-		mspId = si.Identifier().MSPID
-	}
-
-	// the SDK doesn't save the CACert locally, we have to retrieve it from the Fabric CA server
-	cacert, err := w.getCACert()
-	if err != nil {
-		return nil, restutil.NewRestError(err.Error())
-	}
-
 	newId := identity.Identity{}
 	newId.Name = result.ID
 	newId.MaxEnrollments = result.MaxEnrollments
 	newId.CAName = result.CAName
 	newId.Type = result.Type
 	newId.Affiliation = result.Affiliation
-	newId.MSPID = mspId
-	newId.EnrollmentCert = ecert
+
+	// the SDK identity manager does not persist the certificates
+	// we have to retrieve it from the identity manager
+	si, err := w.identityMgr.GetSigningIdentity(username)
+	if err != nil && err != msp.ErrUserNotFound {
+		return nil, restutil.NewRestError(err.Error(), 500)
+	}
+	if err == nil {
+		// the user may have been enrolled by a different client instance
+		ecert := si.EnrollmentCertificate()
+		mspId := si.Identifier().MSPID
+		newId.MSPID = mspId
+		newId.EnrollmentCert = ecert
+	}
+	newId.Organization = w.identityConfig.Client().Organization
+
+	// the SDK doesn't save the CACert locally, we have to retrieve it from the Fabric CA server
+	cacert, err := w.getCACert()
+	if err != nil {
+		return nil, restutil.NewRestError(err.Error(), 500)
+	}
+
 	newId.CACert = cacert
 	return &newId, nil
 }

--- a/internal/rest/identity/identity.go
+++ b/internal/rest/identity/identity.go
@@ -29,6 +29,7 @@ type Identity struct {
 	Type           string `json:"type"`
 	Affiliation    string `json:"affiliation"`
 	CAName         string `json:"caname"`
+	MSPID          string `json:"mspId"`
 	EnrollmentCert []byte `json:"enrollmentCert"`
 	CACert         []byte `json:"caCert"`
 }

--- a/internal/rest/identity/identity.go
+++ b/internal/rest/identity/identity.go
@@ -29,6 +29,8 @@ type Identity struct {
 	Type           string `json:"type"`
 	Affiliation    string `json:"affiliation"`
 	CAName         string `json:"caname"`
+	EnrollmentCert []byte `json:"enrollmentCert"`
+	CACert         []byte `json:"caCert"`
 }
 
 type RegisterResponse struct {

--- a/internal/rest/identity/identity.go
+++ b/internal/rest/identity/identity.go
@@ -29,8 +29,9 @@ type Identity struct {
 	Type           string `json:"type"`
 	Affiliation    string `json:"affiliation"`
 	CAName         string `json:"caname"`
-	MSPID          string `json:"mspId"`
-	EnrollmentCert []byte `json:"enrollmentCert"`
+	Organization   string `json:"organization,omitempty"`
+	MSPID          string `json:"mspId,omitempty"`
+	EnrollmentCert []byte `json:"enrollmentCert,omitempty"`
 	CACert         []byte `json:"caCert"`
 }
 


### PR DESCRIPTION
The certificates for the user and the CA as well as the MSP ID are necessary for building the full Fabric Identity from a simple user name, which follows the pattern `x509::{DN of user cert}::{DN of CA cert}`.

These are added to the `GET /identities/:id` calls only, not to the list calls (`GET /identities`) to avoid lengthy response time